### PR TITLE
deprecate data-parent-el

### DIFF
--- a/src/components/daterangepicker/daterangepicker.vue
+++ b/src/components/daterangepicker/daterangepicker.vue
@@ -11,7 +11,6 @@ import 'daterangepicker';
 import {get} from 'lodash';
 
 import {toDateRangePickerValue, toLocaleString} from '../../lib/date';
-import {attributeToClassSelector} from '../../lib/css-selector';
 
 const monthNames = [
   'January',
@@ -38,7 +37,7 @@ export default {
       default: 'end',
       type: String
     },
-    parentEl: {
+    parentSelector: {
       default: '',
       type: String
     },
@@ -96,7 +95,7 @@ export default {
         endDate: this.endDateFromValue,
         minDate: toDateRangePickerValue(new Date()),
         locale: {monthNames},
-        parentEl: this.parentEl && attributeToClassSelector(this.parentEl)
+        parentEl: this.parentSelector
       },
       (start, end) => {
         this.emit(start, end);

--- a/src/components/daterangepicker/index.js
+++ b/src/components/daterangepicker/index.js
@@ -7,6 +7,7 @@ import {
   vModelFromNode
 } from '../../lib/vue-helpers';
 import PressComponentBase from '../../press-component';
+import {attributeToClassSelector} from '../../lib/css-selector';
 
 Vue.component('daterangepicker', daterangepicker);
 
@@ -27,7 +28,21 @@ export default class DateRangePicker extends PressComponentBase {
 
     const startAttrs = findParameters(el, startEl);
     const endAttrs = findParameters(el, endEl);
-    const parentElAttrs = el.getAttribute('data-parent-el');
+    let {parentSelector} = el.dataset;
+    const {parentEl} = el.dataset;
+    if (parentEl) {
+      let msg =
+        '`data-parent-el` is deprecated. Please pass a valid css selector via `data-parent-selector`.';
+      if (parentSelector) {
+        msg +=
+          ' Since you also passed `data-parent-selector`, you can fix this warning by simply removing `data-parent-el`';
+      } else {
+        parentSelector = attributeToClassSelector(parentEl);
+        msg += `\nYou can fix this warning by replacing 'data-parent-el=${parentEl}' with 'data-parent-selector=${parentSelector}'`;
+      }
+
+      this.logger.warn(msg);
+    }
 
     const baseModelName = this.normalizeParameters(startAttrs, endAttrs);
 
@@ -40,7 +55,9 @@ export default class DateRangePicker extends PressComponentBase {
     drp.setAttribute('v-model', baseModelName);
     drp.setAttribute('start-key', startAttrs.key);
     drp.setAttribute('end-key', endAttrs.key);
-    parentElAttrs && drp.setAttribute('parent-el', parentElAttrs);
+    if (parentSelector) {
+      drp.setAttribute('parent-selector', parentSelector);
+    }
 
     drp.setAttribute(
       'value',


### PR DESCRIPTION
This PR deprecates the data-parent-el attribute in favor of passing a css selector rather than a to-be-transformed string