### PR TITLE
override build step on now

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "lint:types": "npm-run-all lint:types:*",
     "lint:types:src": "tsc",
     "lint:types:features": "tsc --project ./tsconfig.features.json",
+    "now-build": "echo 'now-build is a noop since the server just runs webpack dev server'",
     "plop": "plop",
     "precommit": "lint-staged",
     "semantic-release": "semantic-release",


### PR DESCRIPTION
since we just use webpack-dev-server, there is no need for a build step on now