### PR TITLE
Add TypeNarrowingError

### DIFF
--- a/src/components/datepicker/index.js
+++ b/src/components/datepicker/index.js
@@ -6,6 +6,7 @@ import {
   vModelFromNode
 } from '../../lib/vue-helpers';
 import PressComponentBase from '../../press-component';
+import {TypeNarrowingError} from '../../lib/errors';
 
 Vue.component('datepicker', datepicker);
 
@@ -50,7 +51,7 @@ export default class DatePicker extends PressComponentBase {
   infer(root) {
     Array.from(root.querySelectorAll('input[type="date"]')).forEach((el) => {
       if (!(el instanceof HTMLElement)) {
-        throw new TypeError('PRESS can only infer HTMLElements');
+        throw new TypeNarrowingError();
       }
       const names = el.getAttributeNames();
       if (

--- a/src/lib/errors.js
+++ b/src/lib/errors.js
@@ -1,0 +1,17 @@
+/**
+ * Used in `instanceof` checks to help TSC accept an instance is the expected
+ * type. THIS SHOULD NEVER BE USED WHEN THE CHECK MIGHT FAIL.
+ */
+export class TypeNarrowingError extends Error {
+  /**
+   * @param {string} [message]
+   */
+  constructor(message) {
+    let msg =
+      'The TypeNarrowingError should never be used where it can actually be thrown. It is only to be used to help TypeScript understand what it cannot infer.';
+    if (message) {
+      msg += ` Original Error: ${message}`;
+    }
+    super(msg);
+  }
+}

--- a/src/lib/vueify.js
+++ b/src/lib/vueify.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import {touch} from './touch';
 import {vModelFromNode} from './vue-helpers';
+import {TypeNarrowingError} from './errors';
 
 /**
  * Generates a data model and instantiates a Vue app at el
@@ -13,7 +14,7 @@ export function vueify(root) {
 
   Array.from(root.querySelectorAll('[v-model]')).forEach((el) => {
     if (!(el instanceof HTMLElement)) {
-      throw new TypeError('Only HTMLElements can be vueified');
+      throw new TypeNarrowingError();
     }
     generateModel(el, data);
   });

--- a/src/press-component.js
+++ b/src/press-component.js
@@ -1,3 +1,5 @@
+import {TypeNarrowingError} from './lib/errors';
+
 /**
  * @export
  * @abstract
@@ -7,7 +9,7 @@ export default class PressComponentBase {
   get logger() {
     const logger = loggers.get(this);
     if (!logger) {
-      throw new TypeError(
+      throw new TypeNarrowingError(
         'Somehow, logger is not defined. This should be impossible.'
       );
     }

--- a/src/press.js
+++ b/src/press.js
@@ -1,4 +1,5 @@
 import {vueify} from './lib/vueify';
+import {TypeNarrowingError} from './lib/errors';
 
 export class Press {
   get components() {
@@ -13,7 +14,7 @@ export class Press {
   get logger() {
     const logger = loggers.get(this);
     if (!logger) {
-      throw new TypeError(
+      throw new TypeNarrowingError(
         'Somehow, logger is not defined. This should be impossible.'
       );
     }
@@ -73,7 +74,7 @@ export class Press {
     Array.from(document.querySelectorAll('[data-press-component]')).forEach(
       (el) => {
         if (!(el instanceof HTMLElement)) {
-          throw new TypeError('Only HTMLElements can be enhanced by PRESS');
+          throw new TypeNarrowingError();
         }
         this.enhanceComponent(el);
       }
@@ -127,7 +128,7 @@ export class Press {
     Array.from(document.querySelectorAll('[data-press-app]')).forEach(
       (root) => {
         if (!(root instanceof HTMLElement)) {
-          throw new TypeError('PRESS may only be activated on HTMLElements');
+          throw new TypeNarrowingError();
         }
         vueify(root);
       }


### PR DESCRIPTION
This is an error to be used when we need to narrow a type in situation where we always know that type can be narrowed. In other words, it should **never** be thrown at runtime.

> This is also part of #42, but where possible, I'm trying to carve out self-contained changes