### PR TITLE
Limit commitlint scopes

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -1,3 +1,45 @@
+const path = require('path');
+
+const glob = require('glob');
+
 module.exports = {
-  extends: ['@commitlint/config-conventional']
+  extends: ['@commitlint/config-conventional'],
+  rules: {
+    'scope-enum': async (context = {}) => {
+      const components = await listComponents(context);
+      return [
+        2,
+        'always',
+        components.concat([
+          // build
+          'babel',
+          'npm',
+          'webpack',
+
+          // chores
+          'deps',
+          'deps-dev',
+
+          // all
+          'core',
+
+          // ci
+          'circle',
+          'github',
+          'now',
+          'sauce'
+        ])
+      ];
+    }
+  }
 };
+
+async function listComponents(context) {
+  const cwd = context.cwd || process.cwd();
+  const components = glob.sync('*/', {
+    cwd: path.resolve(cwd, 'src', 'components')
+  });
+  // remove the `press-` prefix since we expect all components to have it and
+  // we're limited to 72 character first-lines.
+  return components.map((c) => c.replace(/^press-/, '').replace(/\/$/, ''));
+}


### PR DESCRIPTION
Since our commit message directly power the changelog, we want to try to maintain some uniformity across the scopes (e.g. the stuff between parenthesis) that we use when writing those messages. This will help the changelog generator group changes more effectively