### PR TITLE
implicitly wait to stabilize tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -47,40 +47,8 @@ jobs:
           at: "."
       - run: npm run lint
 
-  test-MicrosoftEdge-latest:
+  test:
     docker: *docker
-    environment:
-      BROWSER: "MicrosoftEdge-latest"
-    steps: *browser_testing_steps
-
-  test-internet_explorer-11:
-    docker: *docker
-    environment:
-      BROWSER: "internet_explorer-11"
-    steps: *browser_testing_steps
-
-  test-safari-11:
-    docker: *docker
-    environment:
-      BROWSER: "safari-11"
-    steps: *browser_testing_steps
-
-  test-chrome-latest:
-    docker: *docker
-    environment:
-      BROWSER: "chrome-latest"
-    steps: *browser_testing_steps
-
-  test-firefox-latest:
-    docker: *docker
-    environment:
-      BROWSER: "firefox-latest"
-    steps: *browser_testing_steps
-
-  test-firefox-latest-nojs:
-    docker: *docker
-    environment:
-      BROWSER: "firefox-latest-nojs"
     steps: *browser_testing_steps
 
   ensure-valid-credentials:
@@ -118,27 +86,7 @@ workflows:
       - lint:
           requires:
             - install
-      - test-MicrosoftEdge-latest:
-          context: "browser-testing"
-          requires:
-            - install
-      - test-internet_explorer-11:
-          context: "browser-testing"
-          requires:
-            - install
-      - test-safari-11:
-          context: "browser-testing"
-          requires:
-            - install
-      - test-chrome-latest:
-          context: "browser-testing"
-          requires:
-            - install
-      - test-firefox-latest:
-          context: "browser-testing"
-          requires:
-            - install
-      - test-firefox-latest-nojs:
+      - test:
           context: "browser-testing"
           requires:
             - install
@@ -147,12 +95,7 @@ workflows:
           requires:
             - install
             - lint
-            - test-MicrosoftEdge-latest
-            - test-internet_explorer-11
-            - test-safari-11
-            - test-chrome-latest
-            - test-firefox-latest
-            - test-firefox-latest-nojs
+            - test
       - release:
           context: "semantic-release"
           filters:
@@ -161,9 +104,4 @@ workflows:
           requires:
             - install
             - lint
-            - test-MicrosoftEdge-latest
-            - test-internet_explorer-11
-            - test-safari-11
-            - test-chrome-latest
-            - test-firefox-latest
-            - test-firefox-latest-nojs
+            - test

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -8,25 +8,25 @@ Feature: Autocomplete
     When I set "example" to the inputfield "input[name='autocomplete[input]']"
     And I click on the element "input[name='autocomplete[input]']"
     And I press "Tab"
-    Then I expect that element "[name='autocomplete[input]']" contains the text "example"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "example"
+    When I submit a form using element "[type=submit]", I expect values in the following places
+      | Value   | Element Before Submit        | Form After Submit  |
+      | example | [name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Submit a prefilled search string
     Given I open the site "/autocomplete?autocomplete[input]=prefilled"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "prefilled"
-    Then I expect that element "[name='autocomplete[input]']" contains the text "prefilled"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "prefilled"
+    When I submit a form using element "[type=submit]", I expect values in the following places
+      | Value     | Element Before Submit        | Form After Submit  |
+      | prefilled | [name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Change and submit a prefilled search string
     Given I open the site "/autocomplete?autocomplete[input]=prefilled"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "prefilled"
     When I set "example" to the inputfield "input[name='autocomplete[input]']"
     And I press "Tab" in "input[name='autocomplete[input]']"
-    Then I expect that element "[name='autocomplete[input]']" contains the text "example"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "example"
+    And I submit a form using element "[type=submit]", I expect values in the following places
+      | Value   | Element Before Submit        | Form After Submit  |
+      | example | [name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Type letters
     Given This scenario requires JavaScript
@@ -52,20 +52,21 @@ Feature: Autocomplete
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "5" entries
     When I select the autocomplete option with the text "aaa"
-    Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
-    Then I expect that element "[name='autocomplete[input]']" contains the text "aaa"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
+    And I submit a form using element "[type=submit]", I expect values in the following places
+      | Value | Element Before Submit        | Form After Submit  |
+      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input              | autocomplete.input |
 
   Scenario: Select with mouse and submit with enter key
     Given This scenario requires JavaScript
     When I add "a" to the inputfield "input[name='autocomplete[input]']"
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "5" entries
-    When I select the autocomplete option with the text "aaa"
-    Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
-    When I press "Enter"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
+    And I select the autocomplete option with the text "aaa"
+    When I submit a form using the "Enter" key, I expect values in the following places
+      | Value | Element Before Submit        | Form After Submit  |
+      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input              | autocomplete.input |
 
   Scenario: Select autocomplete with keyboard
     Given This scenario requires JavaScript
@@ -76,10 +77,10 @@ Feature: Autocomplete
     And I press "Down"
     And I press "Down"
     And I press "Enter"
-    Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
-    Then I expect that element "[name='autocomplete[input]']" contains the text "aaa"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
+    And I submit a form using element "[type=submit]", I expect values in the following places
+      | Value | Element Before Submit        | Form After Submit  |
+      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input              | autocomplete.input |
 
   Scenario: Select with enter and submit with enter key
     Given This scenario requires JavaScript
@@ -92,10 +93,10 @@ Feature: Autocomplete
     # Safari does something subtly different depending on whether this is
     # "Enter" or "Return". Namely, "Enter" doesn't work
     And I press "Return"
-    Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
-    Then I expect that element "#external-input" contains the text "aaa"
-    When I press "Enter"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
+    And I submit a form using the "Return" key, I expect values in the following places
+      | Value | Element Before Submit        | Form After Submit  |
+      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input              | autocomplete.input |
 
   Scenario: Change the model backing the text
     Given This scenario is pending
@@ -106,6 +107,7 @@ Feature: Autocomplete
     When I set "aaaaa" to the inputfield "#external-input"
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "1" entry
-    Then I expect that element "[name='autocomplete[input]']" contains the text "aaaaa"
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaaaa"
+    When I submit a form using element "[type=submit]", I expect values in the following places
+      | Value | Element Before Submit        | Form After Submit  |
+      | aaaaa | [name='autocomplete[input]'] | autocomplete.input |
+      | aaaaa | #external-input              | autocomplete.input |

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -8,13 +8,15 @@ Feature: Autocomplete
     When I set "example" to the inputfield "input[name='autocomplete[input]']"
     And I click on the element "input[name='autocomplete[input]']"
     And I press "Tab"
-    And I click on the button "[type=submit]"
+    Then I expect that element "[name='autocomplete[input]']" contains the text "example"
+    When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "example"
 
   Scenario: Submit a prefilled search string
     Given I open the site "/autocomplete?autocomplete[input]=prefilled"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "prefilled"
-    And I click on the button "[type=submit]"
+    Then I expect that element "[name='autocomplete[input]']" contains the text "prefilled"
+    When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "prefilled"
 
   Scenario: Change and submit a prefilled search string
@@ -22,7 +24,8 @@ Feature: Autocomplete
     Then I expect that element "input[name='autocomplete[input]']" contains the text "prefilled"
     When I set "example" to the inputfield "input[name='autocomplete[input]']"
     And I press "Tab" in "input[name='autocomplete[input]']"
-    And I click on the button "[type=submit]"
+    Then I expect that element "[name='autocomplete[input]']" contains the text "example"
+    When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "example"
 
   Scenario: Type letters
@@ -50,7 +53,8 @@ Feature: Autocomplete
     Then I expect an autocomplete popup with "5" entries
     When I select the autocomplete option with the text "aaa"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
-    And I click on the button "[type=submit]"
+    Then I expect that element "[name='autocomplete[input]']" contains the text "aaa"
+    When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
 
   Scenario: Select with mouse and submit with enter key
@@ -73,6 +77,7 @@ Feature: Autocomplete
     And I press "Down"
     And I press "Enter"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "aaa"
+    Then I expect that element "[name='autocomplete[input]']" contains the text "aaa"
     When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaa"
 
@@ -101,5 +106,6 @@ Feature: Autocomplete
     When I set "aaaaa" to the inputfield "#external-input"
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "1" entry
+    Then I expect that element "[name='autocomplete[input]']" contains the text "aaaaa"
     When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "autocomplete.input" with a value of "aaaaa"

--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -46,7 +46,7 @@ Feature: Autocomplete
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "1" entries
 
-  Scenario: Select autocomplete with mouse
+  Scenario: Select with mouse and submit with mouse
     Given This scenario requires JavaScript
     When I add "a" to the inputfield "input[name='autocomplete[input]']"
     When I click on the element "input[name='autocomplete[input]']"
@@ -57,7 +57,7 @@ Feature: Autocomplete
       | aaa   | [name='autocomplete[input]'] | autocomplete.input |
       | aaa   | #external-input              | autocomplete.input |
 
-  Scenario: Select with mouse and submit with enter key
+  Scenario: Select with mouse and submit with keyboard
     Given This scenario requires JavaScript
     When I add "a" to the inputfield "input[name='autocomplete[input]']"
     When I click on the element "input[name='autocomplete[input]']"
@@ -68,21 +68,8 @@ Feature: Autocomplete
       | aaa   | [name='autocomplete[input]'] | autocomplete.input |
       | aaa   | #external-input              | autocomplete.input |
 
-  Scenario: Select autocomplete with keyboard
-    Given This scenario requires JavaScript
-    When I add "a" to the inputfield "input[name='autocomplete[input]']"
-    When I click on the element "input[name='autocomplete[input]']"
-    Then I expect an autocomplete popup with "5" entries
-    When I press "Down"
-    And I press "Down"
-    And I press "Down"
-    And I press "Enter"
-    And I submit a form using element "[type=submit]", I expect values in the following places
-      | Value | Element Before Submit        | Form After Submit  |
-      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
-      | aaa   | #external-input              | autocomplete.input |
 
-  Scenario: Select with enter and submit with enter key
+  Scenario: Select with keyboard and submit with keyboard
     Given This scenario requires JavaScript
     When I add "a" to the inputfield "input[name='autocomplete[input]']"
     When I click on the element "input[name='autocomplete[input]']"

--- a/features/datepicker.feature
+++ b/features/datepicker.feature
@@ -8,8 +8,9 @@ Feature: Date Picker
     When I set "January", "1" of next year to the date input "input[placeholder='Enter a date']"
     # need to click somewhere to unfocus the fancy datepicker
     And I click on the element "body"
-    And I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "1" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -23,9 +24,9 @@ Feature: Date Picker
     When I set "January", "1" of next year to the text input "input[placeholder='Enter a date']"
     And I click on the element "body"
     Then I expect that element "#external-input" contains the iso date matching next year's "January", "1"
-    Then I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "1"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "1" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -53,9 +54,9 @@ Feature: Date Picker
     When I set "January", "2" of next year to the date input "#external-input"
     Then I expect that element "#selected-value" contains the iso date matching next year's "January", "2"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "2"
-    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "2"
-    And I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 2    | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -80,9 +81,9 @@ Feature: Date Picker
     And I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "1"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "1"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "1"
-    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "1"
-    And I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "1" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -98,9 +99,9 @@ Feature: Date Picker
     Then I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "15"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "15"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "15"
-    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "15"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "15" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 15   | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -116,9 +117,9 @@ Feature: Date Picker
     Then I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "31"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "31"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "31"
-    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "31"
-    And I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "January", "31" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month   | Date | Element Before Submit            | Form After Submit      |
+      | January | 31   | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -133,9 +134,9 @@ Feature: Date Picker
     And I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "12"
     And I click on the element "input[placeholder='Enter a date']"
     And I select day "1" of the next month
-    Then I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "February", "1"
-    And I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_picker_form.input" of "February", "1" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month    | Date | Element Before Submit            | Form After Submit      |
+      | February | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |

--- a/features/datepicker.feature
+++ b/features/datepicker.feature
@@ -22,7 +22,9 @@ Feature: Date Picker
     Given I open the site "/datepicker_<mode>"
     When I set "January", "1" of next year to the text input "input[placeholder='Enter a date']"
     And I click on the element "body"
-    And I click on the button "[type=submit]"
+    Then I expect that element "#external-input" contains the iso date matching next year's "January", "1"
+    Then I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "1"
+    When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_picker_form.input" of "January", "1" of next year
 
     Examples:
@@ -47,9 +49,11 @@ Feature: Date Picker
     When I set "January", "1" of next year to the text input "input[placeholder='Enter a date']"
     Then I expect that element "#selected-value" contains the iso date matching next year's "January", "1"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "1"
+    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "1"
     When I set "January", "2" of next year to the date input "#external-input"
     Then I expect that element "#selected-value" contains the iso date matching next year's "January", "2"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "2"
+    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "2"
     And I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_picker_form.input" of "January", "2" of next year
 
@@ -76,6 +80,7 @@ Feature: Date Picker
     And I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "1"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "1"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "1"
+    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "1"
     And I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_picker_form.input" of "January", "1" of next year
 
@@ -93,6 +98,7 @@ Feature: Date Picker
     Then I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "15"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "15"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "15"
+    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "15"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_picker_form.input" of "January", "15" of next year
 
@@ -110,6 +116,7 @@ Feature: Date Picker
     Then I expect that element "input[placeholder='Enter a date']" contains the formatted date matching next year's "January", "31"
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "31"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "31"
+    And I expect that element "[name='date_picker_form[input]']" contains the iso date matching next year's "January", "31"
     And I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_picker_form.input" of "January", "31" of next year
 

--- a/features/daterangepicker.feature
+++ b/features/daterangepicker.feature
@@ -11,6 +11,8 @@ Feature: Date Range Picker
     When I set "April", "1" of next year to the date input "[name='date_rangepicker_form[end_date]']"
     # need to click somewhere to unfocus the fancy datepicker
     And I click on the element "body"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
@@ -22,6 +24,8 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
@@ -29,6 +33,10 @@ Feature: Date Range Picker
   Scenario: Submit the default date range
     Given This scenario requires JavaScript
     And I open the site "/daterangepicker"
+
+    # Then I expect that element "[name='date_rangepicker_form[start_date]']"
+    # And I expect that element "[name='date_rangepicker_form[end_date]']"
+
     When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "date_rangepicker_form.start_date" with a value matching /\d{4}-\d{2}-\d{2}/
     And I expect the server received a form parameter named "date_rangepicker_form.end_date" with a value matching /\d{4}-\d{2}-\d{2}/
@@ -42,6 +50,8 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
@@ -52,6 +62,8 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Jan 1, 2019   →   Feb 1, 2019"
     And I expect that element "#external-input-start" contains the text "2019-01-01"
     And I expect that element "#external-input-end" contains the text "2019-02-01"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "January", "1"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "February", "1"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "January", "1" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "February", "1" of next year
@@ -64,7 +76,9 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
-    And I click on the button "[type=submit]"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
+    When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
 
@@ -77,6 +91,8 @@ Feature: Date Range Picker
     And I expect that element "#external-input-end" contains the text "2019-04-02"
     When I set "2019-01-02" to the inputfield "#external-input-start"
     When I set "2019-01-03" to the inputfield "#external-input-end"
+    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "January", "2"
+    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "January", "3"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "January", "2" of next year
     And I expect the server received an iso date named "date_rangepicker_form.end_date" of "January", "3" of next year
@@ -87,6 +103,10 @@ Feature: Date Range Picker
     When I click on the element "[data-press-daterangepicker-input]"
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
+
+    And I expect that element "[name='start_date']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='end_date']" contains the iso date matching next year's "April", "2"
+
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "start_date" of "March", "1" of next year
     And I expect the server received an iso date named "end_date" of "April", "2" of next year
@@ -94,6 +114,10 @@ Feature: Date Range Picker
   Scenario: Submit the default date range (unnested input names)
     Given This scenario requires JavaScript
     And I open the site "/daterangepicker-unnested"
+
+    # Then I expect that element "[name='start_date']" with a value matching /\d{4}-\d{2}-\d{2}/
+    # And I expect that element "[name='end_date']" with a value matching /\d{4}-\d{2}-\d{2}/
+
     When I click on the button "[type=submit]"
     Then I expect the server received a form parameter named "start_date" with a value matching /\d{4}-\d{2}-\d{2}/
     And I expect the server received a form parameter named "end_date" with a value matching /\d{4}-\d{2}-\d{2}/
@@ -106,6 +130,8 @@ Feature: Date Range Picker
     And I click on the element "[data-press-daterangepicker-input]"
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 201"
+    And I expect that element "[name='start_date']" contains the iso date matching next year's "March", "1"
+    And I expect that element "[name='end_date']" contains the iso date matching next year's "April", "2"
     When I click on the button "[type=submit]"
     Then I expect the server received an iso date named "start_date" of "March", "1" of next year
     And I expect the server received an iso date named "end_date" of "April", "2" of next year

--- a/features/daterangepicker.feature
+++ b/features/daterangepicker.feature
@@ -11,11 +11,10 @@ Feature: Date Range Picker
     When I set "April", "1" of next year to the date input "[name='date_rangepicker_form[end_date]']"
     # need to click somewhere to unfocus the fancy datepicker
     And I click on the element "body"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit                      | Form After Submit                |
+      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a date range (js enabled)
     Given This scenario requires JavaScript
@@ -24,11 +23,10 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit                      | Form After Submit                |
+      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit the default date range
     Given This scenario requires JavaScript
@@ -50,11 +48,10 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit                      | Form After Submit                |
+      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a prefilled date range
     Given This scenario requires JavaScript
@@ -62,11 +59,10 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Jan 1, 2019   →   Feb 1, 2019"
     And I expect that element "#external-input-start" contains the text "2019-01-01"
     And I expect that element "#external-input-end" contains the text "2019-02-01"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "January", "1"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "February", "1"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "January", "1" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "February", "1" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month    | Date | Element Before Submit                      | Form After Submit                |
+      | January  | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | February | 1    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Change and submit a prefilled date range
     Given This scenario requires JavaScript
@@ -76,11 +72,10 @@ Feature: Date Range Picker
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "April", "2"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit                      | Form After Submit                |
+      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Change the model backing a date range
     Given This scenario requires JavaScript
@@ -91,11 +86,10 @@ Feature: Date Range Picker
     And I expect that element "#external-input-end" contains the text "2019-04-02"
     When I set "2019-01-02" to the inputfield "#external-input-start"
     When I set "2019-01-03" to the inputfield "#external-input-end"
-    Then I expect that element "[name='date_rangepicker_form[start_date]']" contains the iso date matching next year's "January", "2"
-    And I expect that element "[name='date_rangepicker_form[end_date]']" contains the iso date matching next year's "January", "3"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "date_rangepicker_form.start_date" of "January", "2" of next year
-    And I expect the server received an iso date named "date_rangepicker_form.end_date" of "January", "3" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month    | Date | Element Before Submit                      | Form After Submit                |
+      | Januaury | 2    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | January  | 3    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a date range (js enabled) (unnested input names)
     Given This scenario requires JavaScript
@@ -103,24 +97,19 @@ Feature: Date Range Picker
     When I click on the element "[data-press-daterangepicker-input]"
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
-
-    And I expect that element "[name='start_date']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='end_date']" contains the iso date matching next year's "April", "2"
-
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit | Form After Submit |
+      | March | 1    | [name='start_date']   | start_date        |
+      | April | 2    | [name='end_date']     | end_date          |
 
   Scenario: Submit the default date range (unnested input names)
     Given This scenario requires JavaScript
     And I open the site "/daterangepicker-unnested"
 
-    # Then I expect that element "[name='start_date']" with a value matching /\d{4}-\d{2}-\d{2}/
-    # And I expect that element "[name='end_date']" with a value matching /\d{4}-\d{2}-\d{2}/
-
-    When I click on the button "[type=submit]"
-    Then I expect the server received a form parameter named "start_date" with a value matching /\d{4}-\d{2}-\d{2}/
-    And I expect the server received a form parameter named "end_date" with a value matching /\d{4}-\d{2}-\d{2}/
+    When I submit a form using element "[type=submit]", I expect ISO Dates in the following places
+      | Element Before Submit | Form After Submit |
+      | [name='start_date']   | start_date        |
+      | [name='end_date']     | end_date          |
 
   Scenario: Select and change a date range (unnested input names)
     Given This scenario requires JavaScript
@@ -130,11 +119,10 @@ Feature: Date Range Picker
     And I click on the element "[data-press-daterangepicker-input]"
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 201"
-    And I expect that element "[name='start_date']" contains the iso date matching next year's "March", "1"
-    And I expect that element "[name='end_date']" contains the iso date matching next year's "April", "2"
-    When I click on the button "[type=submit]"
-    Then I expect the server received an iso date named "start_date" of "March", "1" of next year
-    And I expect the server received an iso date named "end_date" of "April", "2" of next year
+    When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
+      | Month | Date | Element Before Submit | Form After Submit |
+      | March | 1    | [name='start_date']   | start_date        |
+      | April | 2    | [name='end_date']     | end_date          |
 
   Scenario: See default Arrive / Depart text on initialization (unnested input names)
     Given This scenario requires JavaScript

--- a/features/steps/custom/when-submit-then.js
+++ b/features/steps/custom/when-submit-then.js
@@ -1,0 +1,92 @@
+'use strict';
+
+// for typescript
+// eslint-disable-next-line no-unused-vars
+const moment = require('moment');
+
+const {
+  momentFromMonthDateNextYear
+} = require('../../support/lib/moment-helpers');
+const {
+  expectServer,
+  expectValue
+} = require('../../support/lib/assertion-helpers');
+const clickElement = require('../../support/action/clickElement');
+const pressButton = require('../../support/action/pressButton');
+
+/** @typedef {moment.Moment|RegExp|string} Expectable */
+/** @typedef {"ISO Dates"|"next year's dates to be represented"|"values"} Mode */
+
+/**
+ * Extracts or constructs the expected value from the hash depending on mode
+ * @param {Mode} mode
+ * @param {Object} hash
+ * @returns {Expectable}
+ */
+function getExpected(mode, hash) {
+  if (mode === 'values') {
+    return hash.Value;
+  }
+
+  if (mode === "next year's dates to be represented") {
+    return momentFromMonthDateNextYear(hash.Month, hash.Date);
+  }
+
+  if (mode === 'ISO Dates') {
+    return /\d{4}-\d{2}-\d{2}/;
+  }
+
+  throw new TypeError(
+    `mode must be one of "ISO Dates", "next year's dates to be represented", or "values", not "${mode}"`
+  );
+}
+
+/**
+ * @param {Mode} mode
+ * @param {string} sel
+ * @param {Expectable} expected
+ */
+function assertBeforeSubmit(mode, sel, expected) {
+  expectValue(sel, expected);
+}
+
+/**
+ * @param {Mode} mode
+ * @param {string} key
+ * @param {Expectable} expected
+ */
+function assertServerAfterSubmit(mode, key, expected) {
+  expectServer(key, expected);
+}
+
+/**
+ *
+ * @param {string} keyName
+ * @param {string} buttonSelector
+ * @param {Mode} mode
+ * @param {any} table
+ */
+function whenSubmitThen(keyName, buttonSelector, mode, table) {
+  /** @type {{sel: string, key: string, expected: string}[]} */
+  const usable = table.hashes().map((hash) => ({
+    expected: getExpected(mode, hash),
+    key: hash['Form After Submit'],
+    sel: hash['Element Before Submit']
+  }));
+
+  for (const {sel, expected} of usable) {
+    assertBeforeSubmit(mode, sel, expected);
+  }
+
+  if (buttonSelector) {
+    clickElement('click', 'selector', buttonSelector);
+  } else {
+    pressButton(keyName, ':focus');
+  }
+
+  for (const {key, expected} of usable) {
+    assertServerAfterSubmit(mode, key, expected);
+  }
+}
+
+exports.whenSubmitThen = whenSubmitThen;

--- a/features/steps/given.js
+++ b/features/steps/given.js
@@ -20,7 +20,12 @@ const isVisible = require('../support/check/isVisible');
 const openWebsite = require('../support/action/openWebsite');
 const resizeScreenSize = require('../support/action/resizeScreenSize');
 
-Given(/^I open the (url|site) "([^"]*)?"$/, openWebsite);
+Given(
+  /^I open the (url|site) "([^"]*)?"$/,
+  // @ts-ignore - wrapperOptions is in the docs, if not in the type definition
+  {wrapperOptions: {retry: 2}},
+  openWebsite
+);
 
 Given(/^the element "([^"]*)?" is( not)* visible$/, isVisible);
 

--- a/features/support/lib/assertion-helpers.js
+++ b/features/support/lib/assertion-helpers.js
@@ -1,0 +1,67 @@
+'use strict';
+const _ = require('lodash');
+const {assert} = require('chai');
+// for typescript
+// eslint-disable-next-line no-unused-vars
+const moment = require('moment');
+
+/** @typedef {moment.Moment|RegExp|string} Expectable */
+
+/**
+ * @param {string} keypath
+ * @param {Expectable} expected
+ */
+function expectServer(keypath, expected) {
+  const req = JSON.parse(
+    browser
+      .elements('#last-req')
+      .getText()
+      .trim()
+  );
+  assert.nestedProperty(req.body, keypath);
+  const actual = _.get(req.body, keypath);
+  assertTextOrPatternOrDate(
+    actual,
+    expected,
+    `Expected value ${actual} at keypath to match ${expected}`
+  );
+}
+exports.expectServer = expectServer;
+
+/**
+ * Asserts that the specified selector contains a value matching value
+ * @param {string} sel
+ * @param {Expectable} expected
+ */
+function expectText(sel, expected) {
+  const actual = browser.getText(sel);
+  assertTextOrPatternOrDate(actual, expected);
+}
+exports.expectText = expectText;
+
+/**
+ * @param {string} actual
+ * @param {Expectable} expected
+ * @param {string} [msg]
+ */
+function assertTextOrPatternOrDate(actual, expected, msg) {
+  if (typeof expected === 'string') {
+    assert.equal(actual, expected, msg);
+  } else if (expected instanceof RegExp) {
+    assert.match(actual, expected, msg);
+  } else {
+    assert.equal(actual, expected.toISOString().split('T')[0], msg);
+  }
+}
+exports.assertTextOrPatternOrDate = assertTextOrPatternOrDate;
+
+/**
+ * Asserts that the specified selector contains a value matching value
+ * @param {string} sel
+ * @param {Expectable} expected
+ */
+function expectValue(sel, expected) {
+  const actual = browser.getValue(sel);
+  assertTextOrPatternOrDate(actual, expected);
+}
+exports.expectValue = expectValue;

--- a/features/support/lib/moment-helpers.js
+++ b/features/support/lib/moment-helpers.js
@@ -1,0 +1,16 @@
+'use strict';
+
+const moment = require('moment');
+
+/**
+ * @param {number} month
+ * @param {number} date
+ * @returns {moment.Moment}
+ */
+function momentFromMonthDateNextYear(month, date) {
+  return moment()
+    .month(month)
+    .date(date)
+    .year(moment().year() + 1);
+}
+exports.momentFromMonthDateNextYear = momentFromMonthDateNextYear;

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -101,6 +101,31 @@ exports.config = {
   capabilities:
     browserFromEnv() ||
     [
+      CI && {
+        browserName: 'MicrosoftEdge',
+        version: 'latest'
+      },
+      CI && {
+        browserName: 'internet explorer',
+        version: '11'
+      },
+      CI && {
+        browserName: 'safari',
+        version: '11'
+      },
+      CI && {
+        browserName: 'chrome',
+        version: 'latest'
+      },
+      CI && {
+        browserName: 'firefox',
+        version: 'latest'
+      },
+      CI && {
+        browserName: 'firefox',
+        profile: firefoxProfileWithJavaScriptDisabled,
+        version: 'latest'
+      },
       // See https://circleci.com/gh/UrbanDoor/press/104 for test failures
       !CI &&
         js && {

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -247,7 +247,7 @@ exports.config = {
     profile: [], // <string[]> (name) specify the profile to use
     strict: false, // <boolean> fail if there are any undefined or pending steps
     tags: [], // <string[]> (expression) only execute the features or scenarios with tags matching the expression
-    timeout: 20000, // <number> timeout for step definitions
+    timeout: 30000, // <number> timeout for step definitions
     ignoreUndefinedDefinitions: false // <boolean> Enable this config to treat undefined definitions as warnings.
   },
 


### PR DESCRIPTION
IE, Edge, and Safari have been very flaky because they have just enough lag for assertions to fail. This PR adds assertions to induce waits that should help stabilize things