### PR TITLE
Fix checkboxes

### DIFF
--- a/features/autocomplete.feature
+++ b/features/autocomplete.feature
@@ -9,15 +9,15 @@ Feature: Autocomplete
     And I click on the element "input[name='autocomplete[input]']"
     And I press "Tab"
     When I submit a form using element "[type=submit]", I expect values in the following places
-      | Value   | Element Before Submit        | Form After Submit  |
-      | example | [name='autocomplete[input]'] | autocomplete.input |
+      | Value   | Element Before Submit             | Form After Submit  |
+      | example | input[name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Submit a prefilled search string
     Given I open the site "/autocomplete?autocomplete[input]=prefilled"
     Then I expect that element "input[name='autocomplete[input]']" contains the text "prefilled"
     When I submit a form using element "[type=submit]", I expect values in the following places
-      | Value     | Element Before Submit        | Form After Submit  |
-      | prefilled | [name='autocomplete[input]'] | autocomplete.input |
+      | Value     | Element Before Submit             | Form After Submit  |
+      | prefilled | input[name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Change and submit a prefilled search string
     Given I open the site "/autocomplete?autocomplete[input]=prefilled"
@@ -25,8 +25,8 @@ Feature: Autocomplete
     When I set "example" to the inputfield "input[name='autocomplete[input]']"
     And I press "Tab" in "input[name='autocomplete[input]']"
     And I submit a form using element "[type=submit]", I expect values in the following places
-      | Value   | Element Before Submit        | Form After Submit  |
-      | example | [name='autocomplete[input]'] | autocomplete.input |
+      | Value   | Element Before Submit             | Form After Submit  |
+      | example | input[name='autocomplete[input]'] | autocomplete.input |
 
   Scenario: Type letters
     Given This scenario requires JavaScript
@@ -53,9 +53,9 @@ Feature: Autocomplete
     Then I expect an autocomplete popup with "5" entries
     When I select the autocomplete option with the text "aaa"
     And I submit a form using element "[type=submit]", I expect values in the following places
-      | Value | Element Before Submit        | Form After Submit  |
-      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
-      | aaa   | #external-input              | autocomplete.input |
+      | Value | Element Before Submit             | Form After Submit  |
+      | aaa   | input[name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input                   | autocomplete.input |
 
   Scenario: Select with mouse and submit with keyboard
     Given This scenario requires JavaScript
@@ -64,9 +64,9 @@ Feature: Autocomplete
     Then I expect an autocomplete popup with "5" entries
     And I select the autocomplete option with the text "aaa"
     When I submit a form using the "Enter" key, I expect values in the following places
-      | Value | Element Before Submit        | Form After Submit  |
-      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
-      | aaa   | #external-input              | autocomplete.input |
+      | Value | Element Before Submit             | Form After Submit  |
+      | aaa   | input[name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input                   | autocomplete.input |
 
 
   Scenario: Select with keyboard and submit with keyboard
@@ -81,9 +81,9 @@ Feature: Autocomplete
     # "Enter" or "Return". Namely, "Enter" doesn't work
     And I press "Return"
     And I submit a form using the "Return" key, I expect values in the following places
-      | Value | Element Before Submit        | Form After Submit  |
-      | aaa   | [name='autocomplete[input]'] | autocomplete.input |
-      | aaa   | #external-input              | autocomplete.input |
+      | Value | Element Before Submit             | Form After Submit  |
+      | aaa   | input[name='autocomplete[input]'] | autocomplete.input |
+      | aaa   | #external-input                   | autocomplete.input |
 
   Scenario: Change the model backing the text
     Given This scenario is pending
@@ -95,6 +95,6 @@ Feature: Autocomplete
     When I click on the element "input[name='autocomplete[input]']"
     Then I expect an autocomplete popup with "1" entry
     When I submit a form using element "[type=submit]", I expect values in the following places
-      | Value | Element Before Submit        | Form After Submit  |
-      | aaaaa | [name='autocomplete[input]'] | autocomplete.input |
-      | aaaaa | #external-input              | autocomplete.input |
+      | Value | Element Before Submit             | Form After Submit  |
+      | aaaaa | input[name='autocomplete[input]'] | autocomplete.input |
+      | aaaaa | #external-input                   | autocomplete.input |

--- a/features/datepicker.feature
+++ b/features/datepicker.feature
@@ -9,8 +9,8 @@ Feature: Date Picker
     # need to click somewhere to unfocus the fancy datepicker
     And I click on the element "body"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 1    | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -25,8 +25,8 @@ Feature: Date Picker
     And I click on the element "body"
     Then I expect that element "#external-input" contains the iso date matching next year's "January", "1"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 1    | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -55,8 +55,8 @@ Feature: Date Picker
     Then I expect that element "#selected-value" contains the iso date matching next year's "January", "2"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "2"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 2    | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 2    | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -82,8 +82,8 @@ Feature: Date Picker
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "1"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "1"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 1    | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -100,8 +100,8 @@ Feature: Date Picker
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "15"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "15"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 15   | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 15   | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -118,8 +118,8 @@ Feature: Date Picker
     And I expect that element "#selected-value" contains the iso date matching next year's "January", "31"
     And I expect that element "#external-input" contains the iso date matching next year's "January", "31"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month   | Date | Element Before Submit            | Form After Submit      |
-      | January | 31   | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month   | Date | Element Before Submit                 | Form After Submit      |
+      | January | 31   | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |
@@ -135,8 +135,8 @@ Feature: Date Picker
     And I click on the element "input[placeholder='Enter a date']"
     And I select day "1" of the next month
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month    | Date | Element Before Submit            | Form After Submit      |
-      | February | 1    | [name='date_picker_form[input]'] | date_picker_form.input |
+      | Month    | Date | Element Before Submit                 | Form After Submit      |
+      | February | 1    | input[name='date_picker_form[input]'] | date_picker_form.input |
 
     Examples:
       | mode           |

--- a/features/daterangepicker.feature
+++ b/features/daterangepicker.feature
@@ -12,9 +12,9 @@ Feature: Date Range Picker
     # need to click somewhere to unfocus the fancy datepicker
     And I click on the element "body"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit                      | Form After Submit                |
-      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month | Date | Element Before Submit                           | Form After Submit                |
+      | March | 1    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a date range (js enabled)
     Given This scenario requires JavaScript
@@ -24,9 +24,9 @@ Feature: Date Range Picker
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit                      | Form After Submit                |
-      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month | Date | Element Before Submit                           | Form After Submit                |
+      | March | 1    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit the default date range
     Given This scenario requires JavaScript
@@ -49,9 +49,9 @@ Feature: Date Range Picker
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit                      | Form After Submit                |
-      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month | Date | Element Before Submit                           | Form After Submit                |
+      | March | 1    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a prefilled date range
     Given This scenario requires JavaScript
@@ -60,9 +60,9 @@ Feature: Date Range Picker
     And I expect that element "#external-input-start" contains the text "2019-01-01"
     And I expect that element "#external-input-end" contains the text "2019-02-01"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month    | Date | Element Before Submit                      | Form After Submit                |
-      | January  | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | February | 1    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month    | Date | Element Before Submit                           | Form After Submit                |
+      | January  | 1    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | February | 1    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Change and submit a prefilled date range
     Given This scenario requires JavaScript
@@ -73,9 +73,9 @@ Feature: Date Range Picker
     And I expect that element "#external-input-start" contains the text "2019-03-01"
     And I expect that element "#external-input-end" contains the text "2019-04-02"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit                      | Form After Submit                |
-      | March | 1    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | April | 2    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month | Date | Element Before Submit                           | Form After Submit                |
+      | March | 1    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | April | 2    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Change the model backing a date range
     Given This scenario requires JavaScript
@@ -87,9 +87,9 @@ Feature: Date Range Picker
     When I set "2019-01-02" to the inputfield "#external-input-start"
     When I set "2019-01-03" to the inputfield "#external-input-end"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month    | Date | Element Before Submit                      | Form After Submit                |
-      | Januaury | 2    | [name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
-      | January  | 3    | [name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
+      | Month    | Date | Element Before Submit                           | Form After Submit                |
+      | Januaury | 2    | input[name='date_rangepicker_form[start_date]'] | date_rangepicker_form.start_date |
+      | January  | 3    | input[name='date_rangepicker_form[end_date]']   | date_rangepicker_form.end_date   |
 
   Scenario: Submit a date range (js enabled) (unnested input names)
     Given This scenario requires JavaScript
@@ -98,18 +98,18 @@ Feature: Date Range Picker
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 2019"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit | Form After Submit |
-      | March | 1    | [name='start_date']   | start_date        |
-      | April | 2    | [name='end_date']     | end_date          |
+      | Month | Date | Element Before Submit    | Form After Submit |
+      | March | 1    | input[name='start_date'] | start_date        |
+      | April | 2    | input[name='end_date']   | end_date          |
 
   Scenario: Submit the default date range (unnested input names)
     Given This scenario requires JavaScript
     And I open the site "/daterangepicker-unnested"
 
     When I submit a form using element "[type=submit]", I expect ISO Dates in the following places
-      | Element Before Submit | Form After Submit |
-      | [name='start_date']   | start_date        |
-      | [name='end_date']     | end_date          |
+      | Element Before Submit    | Form After Submit |
+      | input[name='start_date'] | start_date        |
+      | input[name='end_date']   | end_date          |
 
   Scenario: Select and change a date range (unnested input names)
     Given This scenario requires JavaScript
@@ -120,9 +120,9 @@ Feature: Date Range Picker
     And I select day "1" of the month "March" of next year and day "2" of the month "April" of next year
     Then I expect that element "[data-press-daterangepicker-input]" contains the text "Mar 1, 2019   →   Apr 2, 201"
     When I submit a form using element "[type=submit]", I expect next year's dates to be represented in the following places
-      | Month | Date | Element Before Submit | Form After Submit |
-      | March | 1    | [name='start_date']   | start_date        |
-      | April | 2    | [name='end_date']     | end_date          |
+      | Month | Date | Element Before Submit    | Form After Submit |
+      | March | 1    | input[name='start_date'] | start_date        |
+      | April | 2    | input[name='end_date']   | end_date          |
 
   Scenario: See default Arrive / Depart text on initialization (unnested input names)
     Given This scenario requires JavaScript

--- a/features/form.feature
+++ b/features/form.feature
@@ -1,0 +1,15 @@
+Feature: HTML Forms
+  As an engineer, I expect PRESS-enhanced forms to behave the same as regular HTML forms
+
+  Background:
+    Given I open the site "/form"
+
+  Scenario: Checkbox with a value should be unchecked
+    Then I expect that checkbox "#example_form_unchecked_checkbox" is not checked
+    When I click on the element "[type=submit]"
+    Then I expect the server received a form parameter named "example_form.unchecked_checkbox" with a value of ""0""
+
+  Scenario: Checked checkbox with a value should be checked
+    Then I expect that checkbox "#example_form_checked_checkbox" is checked
+    When I click on the element "[type=submit]"
+    Then I expect the server received a form parameter named "example_form.checked_checkbox" with a value of "["0", "1"]"

--- a/features/server/views/pages/form.ejs
+++ b/features/server/views/pages/form.ejs
@@ -1,0 +1,28 @@
+<% include ../partials/header %>
+<section class="ui basic segment">
+  <header>
+    <h1>PRESS Test Site</h1>
+    <h2>Autocomplete</h2>
+  </header>
+
+  <main class="ui two column grid">
+    <form class="ui form column" method="POST">
+      <h3>Code Under Test</h3>
+
+      <input name="example_form[unchecked_checkbox]" type="hidden" value="0">
+      <input class="boolean optional" type="checkbox" value="1" name="example_form[unchecked_checkbox]" id="example_form_unchecked_checkbox">
+      <label class="boolean optional" for="example_form_unchecked_checkbox">Unchecked on page load</label>
+
+      <input name="example_form[checked_checkbox]" type="hidden" value="0">
+      <input class="boolean optional" type="checkbox" value="1" name="example_form[checked_checkbox]" id="example_form_checked_checkbox" checked>
+      <label class="boolean optional" for="example_form_checked_checkbox">Checked on page load</label>
+
+      <button type="submit">Submit</button>
+    </form>
+
+    <div class="ui column">
+      <%- include ../partials/request.ejs %>
+    </div>
+  </main>
+</section>
+<% include ../partials/footer %>

--- a/features/steps/custom.js
+++ b/features/steps/custom.js
@@ -68,7 +68,7 @@ Then('I expect elements that contain the following text', (table) => {
 Then(
   /^I expect the server received a form parameter named "(.+)" with a value (?:of "(.+)"|matching \/(.+)\/)$/,
   (name, value, pattern) => {
-    expectServer(name, pattern ? new RegExp(pattern) : value);
+    expectServer(name, pattern ? new RegExp(pattern) : JSON.parse(value));
   }
 );
 

--- a/features/steps/when.js
+++ b/features/steps/when.js
@@ -29,7 +29,7 @@ When(/^I drag element "([^"]*)?" to element "([^"]*)?"$/, dragElement);
 
 When(/^I submit the form "([^"]*)?"$/, submitForm);
 
-When(/^I pause for (\d+)ms$/, pause);
+When(/^I (?:pause|sleep|wait) (?:for )?(\d+)ms$/, pause);
 
 When(/^I set a cookie "([^"]*)?" with the content "([^"]*)?"$/, setCookie);
 

--- a/features/support/lib/assertion-helpers.js
+++ b/features/support/lib/assertion-helpers.js
@@ -62,6 +62,10 @@ exports.assertTextOrPatternOrDate = assertTextOrPatternOrDate;
  */
 function expectValue(sel, expected) {
   const actual = browser.getValue(sel);
+  assert.isNotArray(
+    actual,
+    `Expected ${sel} to describe exactly one element on the page`
+  );
   assertTextOrPatternOrDate(actual, expected);
 }
 exports.expectValue = expectValue;

--- a/features/support/lib/assertion-helpers.js
+++ b/features/support/lib/assertion-helpers.js
@@ -5,7 +5,7 @@ const {assert} = require('chai');
 // eslint-disable-next-line no-unused-vars
 const moment = require('moment');
 
-/** @typedef {moment.Moment|RegExp|string} Expectable */
+/** @typedef {moment.Moment|RegExp|any[]|string} Expectable */
 
 /**
  * @param {string} keypath
@@ -20,7 +20,7 @@ function expectServer(keypath, expected) {
   );
   assert.nestedProperty(req.body, keypath);
   const actual = _.get(req.body, keypath);
-  assertTextOrPatternOrDate(
+  smartAssert(
     actual,
     expected,
     `Expected value ${actual} at keypath to match ${expected}`
@@ -35,25 +35,27 @@ exports.expectServer = expectServer;
  */
 function expectText(sel, expected) {
   const actual = browser.getText(sel);
-  assertTextOrPatternOrDate(actual, expected);
+  smartAssert(actual, expected);
 }
 exports.expectText = expectText;
 
 /**
- * @param {string} actual
+ * @param {Object|string} actual
  * @param {Expectable} expected
  * @param {string} [msg]
  */
-function assertTextOrPatternOrDate(actual, expected, msg) {
+function smartAssert(actual, expected, msg) {
   if (typeof expected === 'string') {
     assert.equal(actual, expected, msg);
   } else if (expected instanceof RegExp) {
     assert.match(actual, expected, msg);
-  } else {
+  } else if (moment.isMoment(expected)) {
     assert.equal(actual, expected.toISOString().split('T')[0], msg);
+  } else {
+    assert.deepEqual(actual, expected);
   }
 }
-exports.assertTextOrPatternOrDate = assertTextOrPatternOrDate;
+exports.assertTextOrPatternOrDate = smartAssert;
 
 /**
  * Asserts that the specified selector contains a value matching value
@@ -66,6 +68,6 @@ function expectValue(sel, expected) {
     actual,
     `Expected ${sel} to describe exactly one element on the page`
   );
-  assertTextOrPatternOrDate(actual, expected);
+  smartAssert(actual, expected);
 }
 exports.expectValue = expectValue;

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ import {logger} from './lib/logger';
 export const press = new Press({logger});
 
 performance.mark('press:register:components:start');
+
 // PLOP: START COMPONENT REGISTRATION
 press.registerComponent(new Autocomplete({logger}));
 press.registerComponent(new Datepicker({logger}));

--- a/src/lib/vueify.js
+++ b/src/lib/vueify.js
@@ -7,9 +7,10 @@ import {getAttributeNames} from './polyfills';
 
 /**
  * Generates a data model and instantiates a Vue app at el
+ * @param {Logger} logger
  * @param {HTMLElement} root
  */
-export function vueify(root) {
+export function vueify(logger, root) {
   const data = {isMounted: false};
 
   performance.mark('press:vueify:createmodels:start');
@@ -26,7 +27,7 @@ export function vueify(root) {
   performance.mark('press:vueify:createmodels:end');
 
   performance.mark('press:vueify:fixcheckboxes:start');
-  fixCheckboxes(root);
+  fixCheckboxes(logger, root);
   performance.mark('press:vueify:fixcheckboxes:end');
 
   performance.mark('press:vueify:generatemodel:start');
@@ -98,9 +99,10 @@ function generateModel(el, data) {
 /**
  * Rails, for example, does some novel things to make checkboxes work. We need
  * to make sure PRESS doesn't break them.
+ * @param {Logger} logger
  * @param {HTMLElement} root
  */
-function fixCheckboxes(root) {
+function fixCheckboxes(logger, root) {
   Array.from(root.querySelectorAll('input[type="hidden"]')).forEach((el) => {
     if (!(el instanceof HTMLInputElement)) {
       throw new TypeNarrowingError();
@@ -111,8 +113,10 @@ function fixCheckboxes(root) {
       const checkboxes = root.querySelectorAll(
         `input[type="checkbox"][name="${name}"]`
       );
-      if (checkboxes.length) {
+      if (checkboxes.length === 1) {
         el.removeAttribute('v-model');
+      } else if (checkboxes.length > 1) {
+        logger.warn(`multiple checkboxes appear to have the name ${name}`);
       }
     }
   });

--- a/src/lib/vueify.js
+++ b/src/lib/vueify.js
@@ -62,14 +62,21 @@ function generateModel(el, data) {
   const vModelName = vModelFromNode(el);
 
   let defaultValue = null;
-  if (el.nodeName.toLowerCase() === 'select') {
-    /** @type {HTMLOptionElement|null} */
-    const option = el.querySelector('option[selected]');
-    if (option) {
-      defaultValue = option.value;
-    }
-  } else if (attributeNames.includes('value')) {
-    defaultValue = el.getAttribute('value');
+  switch (el.nodeName.toLowerCase()) {
+    case 'select':
+      {
+        /** @type {HTMLOptionElement|null} */
+        const option = el.querySelector('option[selected]');
+        if (option) {
+          defaultValue = option.value;
+        }
+      }
+      break;
+    default:
+      if (attributeNames.includes('value')) {
+        defaultValue = el.getAttribute('value');
+      }
   }
+
   touch(data, vModelName, defaultValue);
 }

--- a/src/press.js
+++ b/src/press.js
@@ -125,7 +125,7 @@ export class Press {
         if (!(root instanceof HTMLElement)) {
           throw new TypeNarrowingError();
         }
-        vueify(root);
+        vueify(this.logger, root);
       }
     );
     this.logger.info('Vueified non-apped PRESS component');


### PR DESCRIPTION
HTML checkbox inputs don't behave quite the way they would if they were designed today, hence Rails does some [weird stuff](https://api.rubyonrails.org/v5.2.0/classes/ActionView/Helpers/FormHelper.html#method-i-check_box) with hidden inputs and assumptions about the POST payload to deal with them. 

This PR maintains compatibility with this behavior by removing any hidden inputs sharing a `name` with a checkbox from the page's `Vue` model. This solves the immediate problem for us with Rails, though I suspect long-term we might need to create a `press-checkbox` and `press-checkbox-hidden-input` to ensure the behavior remains consistent for non-rails users. Alternatively, I supposed, we might consider a Rails/non-Rails boolean somewhere.

Most of the commits are refactors and test fixes. The interesting logical change is in https://github.com/UrbanDoor/press/commit/b438872412eaedb64a4592ce9c53d1a01db5170b