### PR TITLE
fix(core): make PRESSed selects behave like selects

### DIFF
--- a/features/form.feature
+++ b/features/form.feature
@@ -30,3 +30,42 @@ Feature: HTML Forms
     Then I expect that element "input[name=count]" contains the text "1"
     When I click on the button "#button-with-name"
     Then I expect that element "input[name=count]" contains the text "2"
+
+  Scenario Outline: <Test Name>: Select Box behavior and Form Submission
+    Given I open the site "<Path>"
+    Then I expect that element "[name=<Input Name>]" contains the value "<Initial>"
+    When I click on the element "[type=submit]"
+    Then I expect the server received a form parameter named "<Input Name>" with a value of "\"<Initial>\""
+    When I select the option with the text "One" for element "[name=<Input Name>]"
+    Then I expect that element "[name=<Input Name>]" contains the value "1"
+    When I select the option with the value "3" for element "[name=<Input Name>]"
+    Then I expect that element "[name=<Input Name>]" contains the value "3"
+    When I click on the button "[type=submit]"
+    Then I expect the server received a form parameter named "<Input Name>" with a value of "\"3\""
+    Examples:
+      | Test Name                         | Input Name                 | Path                               | Initial |
+      | No Placeholder/No Default Value   | select_without_placeholder | /form                              | 1       |
+      | No Placeholder/Default Value is 2 | select_without_placeholder | /form?select_without_placeholder=2 | 2       |
+      | Placeholder/No Default Value      | select_with_placeholder    | /form                              |         |
+      | Placeholder/Default Value is 2    | select_with_placeholder    | /form?select_with_placeholder=2    | 2       |
+
+  Scenario: required select with placeholder
+    Given I open the site "/form?require-select_with_placeholder"
+    And I expect that element "[name=select_with_placeholder][required]" does exist
+    Then I expect that element "[name=select_with_placeholder]" contains the value ""
+    And I expect that element ":invalid" does exist
+    When I click on the element "[type=submit]"
+    Then I expect that element ":invalid" does exist
+    When I select the option with the value "3" for element "[name=select_with_placeholder]"
+    Then I expect that element ":invalid" does not exist
+    And I click on the element "[type=submit]"
+    Then I expect the server received a form parameter named "select_with_placeholder" with a value of "\"3\""
+
+  Scenario: required select without placeholder
+    Given I open the site "/form?require-select_without_placeholder"
+    And I expect that element "[name=select_without_placeholder][required]" does exist
+    Then I expect that element "[name=select_without_placeholder]" contains the value "1"
+    And I expect that element "form:invalid" does not exist
+    When I click on the element "[type=submit]"
+    Then I expect that element "form:invalid" does not exist
+    And I expect the server received a form parameter named "select_without_placeholder" with a value of "\"1\""

--- a/features/server/index.js
+++ b/features/server/index.js
@@ -49,6 +49,20 @@ app.use((req, res, next) => {
     .filter((filename) => filename !== 'index.ejs')
     .map((filename) => filename.replace('.ejs', ''));
 
+  res.locals.required = (name) => {
+    if (_.has(req, `query.require-${name}`)) {
+      return ' required ';
+    }
+    return '';
+  };
+
+  res.locals.selected = (name, value) => {
+    if (String(_.get(req, `query.${name}`)) === String(value)) {
+      return ' selected ';
+    }
+    return '';
+  };
+
   res.locals.valueObject = (names) => {
     const obj = names.reduce((acc, name) => {
       acc[name] = _.get(req, `query.${name}`);
@@ -63,6 +77,7 @@ app.use((req, res, next) => {
     }
     return '';
   };
+
   next();
 });
 

--- a/features/server/views/pages/form.ejs
+++ b/features/server/views/pages/form.ejs
@@ -23,6 +23,19 @@
       <button id="button-without-name" type="button" @click="count++">Increase Counter</button>
       <button id="button-with-name" type="button" @click="count++" name="button_with_name">Increase Counter</button>
 
+      <select name="select_with_placeholder" <%- required('select_with_placeholder') %>>
+        <option value="">Placeholder</option>
+        <option value="1" <%- selected('select_with_placeholder', '1') %>>One</option>
+        <option value="2" <%- selected('select_with_placeholder', '2') %>>Two</option>
+        <option value="3" <%- selected('select_with_placeholder', '3') %>>Three</option>
+      </select>
+
+      <select name="select_without_placeholder" <%- required('select_without_placeholder') %>>
+        <option value="1" <%- selected('select_without_placeholder', '1') %>>One</option>
+        <option value="2" <%- selected('select_without_placeholder', '2') %>>Two</option>
+        <option value="3" <%- selected('select_without_placeholder', '3') %>>Three</option>
+      </select>
+
       <button type="submit">Submit</button>
     </form>
 

--- a/features/steps/custom.js
+++ b/features/steps/custom.js
@@ -89,6 +89,14 @@ Then(
 );
 
 Then(
+  /^I expect that element "(.+)" contains the value "(.*)"$/,
+  (selector, value) => {
+    const el = browser.element(selector);
+    assert.equal(el.getValue(), value);
+  }
+);
+
+Then(
   /^I expect that element "(.+)" contains the (iso date|formatted date|native formatted date) matching next year's "(.+)", "(.+)"$/,
   (selector, type, month, date) => {
     const el = browser.elements(selector);

--- a/features/support/check/checkContainsText.js
+++ b/features/support/check/checkContainsText.js
@@ -8,6 +8,10 @@ const {expect} = require('chai');
  * @param  {string}   expectedText  The text to check against
  */
 module.exports = (elementType, element, negate, expectedText) => {
+  if (typeof expectedText === 'undefined') {
+    expectedText = '';
+  }
+
   /**
    * The command to perform on the browser object
    * @type {String}

--- a/features/support/check/checkEqualsText.js
+++ b/features/support/check/checkEqualsText.js
@@ -7,6 +7,10 @@
  * @param  {string}   expectedText  The text to validate against
  */
 module.exports = (elementType, element, negate, expectedText) => {
+  if (typeof expectedText === 'undefined') {
+    expectedText = '';
+  }
+
   /**
    * The command to execute on the browser object
    * @type {String}

--- a/src/components/press-datepicker/index.js
+++ b/src/components/press-datepicker/index.js
@@ -1,13 +1,12 @@
 import Vue from 'vue';
 
-import {wrapWith} from '../../lib/html';
+import {wrapWith, querySelectorAll} from '../../lib/html';
 import {
   bindToHiddenInput,
   normalizeKeyPath,
   vModelFromNode
 } from '../../lib/vuetilities';
 import PressComponentBase from '../../press-component';
-import {TypeNarrowingError} from '../../lib/errors';
 import {closest} from '../../lib/polyfills';
 
 import datepicker from './press-datepicker.vue';
@@ -40,10 +39,7 @@ export default class DatePicker extends PressComponentBase {
    * @param {Document|HTMLElement} root
    */
   infer(root) {
-    Array.from(root.querySelectorAll('input[type="date"]')).forEach((el) => {
-      if (!(el instanceof HTMLElement)) {
-        throw new TypeNarrowingError();
-      }
+    querySelectorAll(root, 'input[type="date"]').forEach((el) => {
       if (closest(el, 'press-noscript')) {
         return;
       }

--- a/src/lib/html.js
+++ b/src/lib/html.js
@@ -63,3 +63,14 @@ export function addRemoteScriptToPage(src) {
     ' type="text/javascript"><' + '/script>');
   /* eslint-enable prefer-template */
 }
+
+/**
+ * Wraps querySelectorAll() to ensure it always returns an Array of HTMLELements
+ * instead of a NodeList of Element|HTMLElement
+ * @param {Document|HTMLElement} root
+ * @param {string} selector
+ * @returns {HTMLElement[]}
+ */
+export function querySelectorAll(root, selector) {
+  return Array.from(root.querySelectorAll(selector));
+}

--- a/src/lib/vueify.js
+++ b/src/lib/vueify.js
@@ -27,6 +27,7 @@ export function vueify(logger, root) {
 
   performance.mark('press:vueify:fixcheckboxes:start');
   fixCheckboxes(logger, root);
+  fixSelects(logger, root);
   performance.mark('press:vueify:fixcheckboxes:end');
 
   performance.mark('press:vueify:generatemodel:start');
@@ -114,6 +115,23 @@ function fixCheckboxes(logger, root) {
         el.removeAttribute('v-model');
       } else if (checkboxes.length > 1) {
         logger.warn(`multiple checkboxes appear to have the name ${name}`);
+      }
+    }
+  });
+}
+
+/**
+ *
+ * @param {Logger} logger
+ * @param {HTMLElement} root
+ */
+function fixSelects(logger, root) {
+  querySelectorAll(root, 'select').forEach((el) => {
+    const options = el.querySelectorAll('option[selected]');
+    if (options.length === 0) {
+      const first = el.querySelector('option');
+      if (first) {
+        first.setAttribute('selected', '');
       }
     }
   });

--- a/src/lib/vueify.js
+++ b/src/lib/vueify.js
@@ -4,7 +4,7 @@ import {touch} from './touch';
 import {vModelFromNode, normalizeKeyPath} from './vuetilities';
 import {TypeNarrowingError} from './errors';
 import {getAttributeNames} from './polyfills';
-
+import {querySelectorAll} from './html';
 /**
  * Generates a data model and instantiates a Vue app at el
  * @param {Logger} logger
@@ -16,15 +16,10 @@ export function vueify(logger, root) {
   performance.mark('press:vueify:createmodels:start');
   // Ensure all named elements have v-models so their contents are available to
   // the page model
-  Array.from(
-    root.querySelectorAll(
-      '[name]:not([v-model]):not(button):not([type="submit"]):not([type="button"])'
-    )
+  querySelectorAll(
+    root,
+    '[name]:not([v-model]):not(button):not([type="submit"]):not([type="button"])'
   ).forEach((el) => {
-    if (!(el instanceof HTMLElement)) {
-      throw new TypeNarrowingError();
-    }
-
     const vModelName = normalizeKeyPath(vModelFromNode(el));
     el.setAttribute('v-model', vModelName);
   });
@@ -35,10 +30,7 @@ export function vueify(logger, root) {
   performance.mark('press:vueify:fixcheckboxes:end');
 
   performance.mark('press:vueify:generatemodel:start');
-  Array.from(root.querySelectorAll('[v-model]')).forEach((el) => {
-    if (!(el instanceof HTMLElement)) {
-      throw new TypeNarrowingError();
-    }
+  querySelectorAll(root, '[v-model]').forEach((el) => {
     generateModel(el, data);
   });
   performance.mark('press:vueify:generatemodel:start');
@@ -112,11 +104,7 @@ function generateModel(el, data) {
  * @param {HTMLElement} root
  */
 function fixCheckboxes(logger, root) {
-  Array.from(root.querySelectorAll('input[type="hidden"]')).forEach((el) => {
-    if (!(el instanceof HTMLInputElement)) {
-      throw new TypeNarrowingError();
-    }
-
+  querySelectorAll(root, 'input[type="hidden"]').forEach((el) => {
     const name = el.getAttribute('name');
     if (name) {
       const checkboxes = root.querySelectorAll(

--- a/src/press-component.js
+++ b/src/press-component.js
@@ -20,7 +20,11 @@ export default class PressComponentBase {
     return logger;
   }
 
-  /** constructor */
+  /**
+   * constructor
+   * @param {Object} options
+   * @param {Logger} options.logger
+   */
   constructor({logger}) {
     loggers.set(this, logger);
   }

--- a/src/press.js
+++ b/src/press.js
@@ -1,6 +1,7 @@
 import {TypeNarrowingError} from './lib/errors';
 import {startsWith} from './lib/polyfills';
 import {vueify} from './lib/vueify';
+import {querySelectorAll} from './lib/html';
 
 /** @type {WeakMap<Press, Map<string, IPressComponent>>} */
 const components = new WeakMap();
@@ -91,13 +92,10 @@ export class Press {
       // This is the right place to check for enhance...
       if (component.enhance) {
         this.logger.info(`Enhancing ${name}`);
-        const elements = Array.from(document.querySelectorAll(name));
+        const elements = querySelectorAll(document, name);
         elements.forEach((el) => {
           // ...and this is where typescript thinks we need to check for enhance
           if (component.enhance) {
-            if (!(el instanceof HTMLElement)) {
-              throw new TypeNarrowingError();
-            }
             this.logger.info(`Enhancing a ${name} instance`);
             component.enhance(el);
             this.logger.info(`Enhanced a ${name} instance`);
@@ -120,14 +118,9 @@ export class Press {
   activate() {
     performance.mark('press:activate:start');
     this.logger.info('Vueifying non-apped PRESS component');
-    Array.from(document.querySelectorAll('[data-press-app]')).forEach(
-      (root) => {
-        if (!(root instanceof HTMLElement)) {
-          throw new TypeNarrowingError();
-        }
-        vueify(this.logger, root);
-      }
-    );
+    querySelectorAll(document, '[data-press-app]').forEach((root) => {
+      vueify(this.logger, root);
+    });
     this.logger.info('Vueified non-apped PRESS component');
     performance.mark('press:activate:end');
   }


### PR DESCRIPTION
If a `select` doesn't contain a selected option, Vue will insert an option at the top of the list with `value=""`. This ensures that, if no item is specified as select by the server, the first item will appear selected to mimic default HTML behavior. 